### PR TITLE
fix: Add title & metadata for homepage

### DIFF
--- a/src/views/pages/home/home.js
+++ b/src/views/pages/home/home.js
@@ -10,6 +10,11 @@ export default class HomePage extends React.Component {
   render() {
     return (
       <>
+        <Seo
+          title='Nano Community'
+          description='Nano community gateway and wiki knowledge hub. Nano is digital money (cryptocurrency) that is peer-to-peer, feeless, instant, green and energy sustainable.'
+          tags='nano, wiki, crypto, currency, cryptocurrency, digital, money, feeless, guide, docs, energy, green, sustainable'
+        />
         <div className='posts'>
           <div className='posts__title'>Posts from the community</div>
           <Posts title='Top' id='top' age={168} />


### PR DESCRIPTION
Metadata is currently not updated when navigating to the home page via an element using react-router / react-router-dom (e.g. the Nano icon) - most noticeable by the title not updating from the previous value when navigating to a doc page, then tapping on the Nano icon to navigate back to the homepage. 

We _should_ be able to remove this data from `index.html`, to avoid repetition, but I'm not 100% sure that this wouldn't cause a regression in the SEO work, so I'm not including that in this change.